### PR TITLE
fix: resolution filter background and asciidocify content

### DIFF
--- a/_frontend/css/resolution.css
+++ b/_frontend/css/resolution.css
@@ -33,6 +33,14 @@
   /* Search + filter bar (reuses std-filter) */
   .res-page .std-filter {
     margin-bottom: 1.5rem;
+    padding: 1rem 1.25rem;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+  }
+  .dark .res-page .std-filter {
+    background: #0f172a;
+    border-color: #334155;
   }
 
   .res-page .std-filter__search-wrap {

--- a/_layouts/resolution_detail.html
+++ b/_layouts/resolution_detail.html
@@ -63,7 +63,7 @@ layout: base
           {% if consideration.type %}
           <span class="std-page__badge" style="margin-bottom:0.5rem">{{ consideration.type | capitalize }}</span>
           {% endif %}
-          <p style="white-space:pre-line">{{ consideration.message }}</p>
+          <div>{{ consideration.message | asciidocify }}</div>
         </div>
         {% unless forloop.last %}<hr style="border:none;border-top:1px solid #e2e8f0;margin:1rem 0">{% endunless %}
         {% endfor %}
@@ -83,7 +83,7 @@ layout: base
           {% if action.subject %}
           <p style="font-weight:600;margin-bottom:0.25rem">{{ action.subject }}</p>
           {% endif %}
-          <p style="white-space:pre-line">{{ action.message }}</p>
+          <div>{{ action.message | asciidocify }}</div>
           {% for d in action.dates %}
             {% if d.start %}
             <p class="std-page__badge" style="margin-top:0.5rem">Effective: {{ d.start }}{% if d.end %} &ndash; {{ d.end }}{% endif %}</p>

--- a/_pages/resolutions.html
+++ b/_pages/resolutions.html
@@ -49,6 +49,8 @@ layout: base
         {% if r.source_type %}<span class="std-results__type">{% case r.source_type %}{% when 'plenary' %}Plenary{% when 'ballot' %}Ballot{% when '7372ma' %}7372 MA{% endcase %}</span>{% endif %}
       </div>
       {% if r.title %}<p class="std-results__title">{{ r.title }}</p>{% endif %}
+      {% assign snippet = r.actions.first.message | default: "" | asciidocify | strip_html | strip_newlines | truncate: 120 %}
+      {% if snippet != "" %}<p class="std-results__title">{{ snippet }}</p>{% endif %}
       <div style="display:flex;gap:0.375rem;align-items:center;margin-top:auto">
         {% if r.year %}<span class="std-results__badge">{{ r.year }}</span>{% endif %}
       </div>
@@ -63,7 +65,7 @@ layout: base
 {%- assign all = site.data.resolutions_all -%}
 {%- for r in all -%}
   {%- unless forloop.first %},{% endunless -%}
-  {"id":"{{ r.identifier }}","title":{{ r.title | jsonify }},"year":"{{ r.year }}","source":"{{ r.source_type }}","group":"{{ r.group_id }}","snippet":{{ r.actions.first.message | default: "" | strip_newlines | truncate: 120 | jsonify }},"url":"/resolutions/{{ r.source_type }}/{{ r.source_file }}/{{ r.identifier | replace: '/', '-' }}/"}
+  {"id":"{{ r.identifier }}","title":{{ r.title | jsonify }},"year":"{{ r.year }}","source":"{{ r.source_type }}","group":"{{ r.group_id }}","snippet":{{ r.actions.first.message | default: "" | asciidocify | strip_html | strip_newlines | truncate: 120 | jsonify }},"url":"/resolutions/{{ r.source_type }}/{{ r.source_file }}/{{ r.identifier | replace: '/', '-' }}/"}
 {%- endfor -%}
 ]
 </script>


### PR DESCRIPTION
Add solid background to resolution search filter box so results do not show through. Apply asciidocify filter to consideration and action messages in resolution detail pages.