### PR TITLE
feat: switch to ISO red logo, add red brand accents

### DIFF
--- a/_frontend/css/footer.css
+++ b/_frontend/css/footer.css
@@ -92,13 +92,12 @@
 
   .site-footer__bottom {
     padding-top: 2rem;
-    border-top: 1px solid rgb(229 231 235 / 0.6);
+    border-top: 2px solid #e3000f;
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 1rem;
   }
-  .dark .site-footer__bottom { border-top-color: rgb(255 255 255 / 0.06); }
   @media (min-width: 640px) {
     .site-footer__bottom { flex-direction: row; justify-content: space-between; }
   }

--- a/_frontend/css/header.css
+++ b/_frontend/css/header.css
@@ -1,6 +1,16 @@
 /* ── Site Header ─────────────────────────────────── */
 
 @layer components {
+  .site-brand-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: #e3000f;
+    z-index: 51;
+  }
+
   .site-header {
     position: fixed;
     top: 0;

--- a/_frontend/css/home.css
+++ b/_frontend/css/home.css
@@ -86,7 +86,7 @@
   .hero-badge .dot {
     width: 0.5rem;
     height: 0.5rem;
-    background: #4ade80;
+    background: #e3000f;
     border-radius: 50%;
     animation: pulse 2s ease-in-out infinite;
   }

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,8 +4,8 @@
       <!-- Brand -->
       <div class="site-footer__brand">
         <a href="/" class="site-footer__logo">
-          <img src="/assets/iso-blue.svg" alt="ISO" class="dark:hidden">
-          <img src="/assets/iso-blue.svg" alt="ISO" class="hidden dark:block">
+          <img src="/assets/iso-red.svg" alt="ISO" class="dark:hidden">
+          <img src="/assets/iso-red.svg" alt="ISO" class="hidden dark:block">
           <span class="site-footer__logo-text">ISO/TC 154</span>
         </a>
         <p class="site-footer__tagline">Processes, data elements and documents in commerce, industry and administration.</p>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,10 +1,11 @@
 <!-- Fixed Navigation Header -->
+<div class="site-brand-bar" aria-hidden="true"></div>
 <header id="nav-header" class="site-header">
   <div class="site-header__inner">
     <!-- Logo -->
     <a href="/" class="site-header__logo">
-      <img src="/assets/iso-blue.svg" alt="ISO" class="dark:hidden">
-      <img src="/assets/iso-blue.svg" alt="ISO" class="hidden dark:block">
+      <img src="/assets/iso-red.svg" alt="ISO" class="dark:hidden">
+      <img src="/assets/iso-red.svg" alt="ISO" class="hidden dark:block">
       <span class="site-header__logo-text">ISO/TC 154</span>
     </a>
 


### PR DESCRIPTION
## Summary

- Switch header and footer from blue ISO logo to official red ISO logo per TPM Laura Mathew guidance
- Add 3px red brand bar at the top of every page (above the fixed header)
- Add 2px red divider in the footer bottom section (visible in both light and dark modes)
- Red is used only as decorative brand accent — blue remains the primary interactive color

## Test plan

- [ ] Verify red ISO logo appears in header and footer (light + dark mode)
- [ ] Verify 3px red bar at top of page
- [ ] Verify 2px red footer divider in both light and dark modes
- [ ] Confirm blue interactive colors (links, buttons) are unchanged

Related: iso-tc154/isotc154.github.io#62